### PR TITLE
支持获取弹幕权重

### DIFF
--- a/src/api/danMaKuApi.py
+++ b/src/api/danMaKuApi.py
@@ -56,7 +56,8 @@ def DeserializeNormalSegmentedPacketDanMaKu(data) -> list[tuple]:
             it.pool,                #5 pool <-> 弹幕池类型 (0 普通, 2 bas)
             it.midHash,             #6 midHash <-> 发送者mid的HASH
             it.id,                  #7 id <-> 弹幕dmid: int32 唯一的!
-            it.content              #8 content <-> 弹幕内容
+            it.weight,              #8 weight <-> 弹幕权重
+            it.content              #9 content <-> 弹幕内容
         )
     return list(map(_extractInfo, danmakuSeg.elems))
 

--- a/src/mainWindow.py
+++ b/src/mainWindow.py
@@ -337,7 +337,7 @@ class VideoScraperUI:
                 self.dmIdCnt.add(int(it[7]))
                 # 写入弹幕
                 writeXmlDm.append(
-                    f'<d p="{it[0]},{it[1]},{it[2]},{it[3]},{it[4]},{it[5]},{it[6]},{it[7]}">{it[8]}</d>\n'
+                    f'<d p="{it[0]},{it[1]},{it[2]},{it[3]},{it[4]},{it[5]},{it[6]},{it[7]},{it[8]}">{it[9]}</d>\n'
                 )
                 if int(it[1]) == 7:
                     seniorDmCnt += 1


### PR DESCRIPTION
## 理由

权重字段可用于本地过滤弹幕(b站旧版的弹幕等级屏蔽功能)

## 介绍

其位于xml p attr的第9个节点(早期仅8个节点，即目前输出格式，故权重位为非必须解析项)

即
```
607.22000,1,25,16777215,1626594185,0,72e4febc,52141495683121157,6
2658.27900,1,25,16777215,1627259772,0,8e0b6f18,52490454768812035,5
2579.76900,1,25,16777215,1626586213,0,c28dd7ce,52137315860480005,0
                                                              这里^~
```

范围为 [0,10] 的整数
数字越大，可视为质量越高

## 修改方法

[DeserializeNormalSegmentedPacketDanMaKu(data) -> list[tuple]](https://github.com/HengXin666/BiLiBiLi_DanMu_Crawling/blob/587d07a0aeab4a049a7b631e43b21bed3945afd9/src/api/danMaKuApi.py#L43)函数下进行修改

原：

```python
def DeserializeNormalSegmentedPacketDanMaKu(data) -> list[tuple]:
    """
    反序列化 普通分段包弹幕
    """
    danmakuSeg = Danmaku.DmSegMobileReply()
    danmakuSeg.ParseFromString(data)
    def _extractInfo(it):
        return (
            it.progress / 1000.0,   #0 progress <-> 出现时间 # (需要 / 1000) xml为float类型
            it.mode,                #1 mode <-> 弹幕类型
            it.fontsize,            #2 fontsize <-> 弹幕字号
            it.color,               #3 color <-> 弹幕颜色
            it.ctime,               #4 ctime <-> 弹幕发送时间
            it.pool,                #5 pool <-> 弹幕池类型 (0 普通, 2 bas)
            it.midHash,             #6 midHash <-> 发送者mid的HASH
            it.id,                  #7 id <-> 弹幕dmid: int32 唯一的!
            it.content              #8 content <-> 弹幕内容
        )
    return list(map(_extractInfo, danmakuSeg.elems))
```

现：

```python
def DeserializeNormalSegmentedPacketDanMaKu(data) -> list[tuple]:
    """
    反序列化 普通分段包弹幕
    """
    danmakuSeg = Danmaku.DmSegMobileReply()
    danmakuSeg.ParseFromString(data)
    def _extractInfo(it):
        return (
            it.progress / 1000.0,   #0 progress <-> 出现时间 # (需要 / 1000) xml为float类型
            it.mode,                #1 mode <-> 弹幕类型
            it.fontsize,            #2 fontsize <-> 弹幕字号
            it.color,               #3 color <-> 弹幕颜色
            it.ctime,               #4 ctime <-> 弹幕发送时间
            it.pool,                #5 pool <-> 弹幕池类型 (0 普通, 2 bas)
            it.midHash,             #6 midHash <-> 发送者mid的HASH
            it.id,                  #7 id <-> 弹幕dmid: int32 唯一的!
            it.weight              #8 weight <-> 弹幕权重
            it.content              #9 content <-> 弹幕内容
        )
    return list(map(_extractInfo, danmakuSeg.elems))
```

[def saveDanMaKu(self, date, dmList) -> int](https://github.com/HengXin666/BiLiBiLi_DanMu_Crawling/blob/587d07a0aeab4a049a7b631e43b21bed3945afd9/src/mainWindow.py#L322)函数

原：

```python
    def saveDanMaKu(self, date, dmList) -> int:
        """保存弹幕

        Args:
            date (str): 当前爬取的日期
            dmList (list): 弹幕列表

        Returns:
            int: 新增弹幕数量
        """
        writeXmlDm = []
        seniorDmCnt = 0
        nowAdd = 0
        for it in dmList:
            if int(it[7]) not in self.dmIdCnt:
                self.dmIdCnt.add(int(it[7]))
                # 写入弹幕
                writeXmlDm.append(
                    f'<d p="{it[0]},{it[1]},{it[2]},{it[3]},{it[4]},{it[5]},{it[6]},{it[7]}">{it[8]}</d>\n'
                )
                if int(it[1]) == 7:
                    seniorDmCnt += 1
                nowAdd += 1
        self.allDmCnt += nowAdd
        self.seniorDmCnt += seniorDmCnt
        self.queue.put(f"爬取 {date} 获取 {len(dmList)} 条弹幕; 新增 {nowAdd} 条弹幕, 高级弹幕新增 {seniorDmCnt} 条.")
        self.queue.put(writeXmlDm)
        return nowAdd
```

现：

```python
    def saveDanMaKu(self, date, dmList) -> int:
        """保存弹幕

        Args:
            date (str): 当前爬取的日期
            dmList (list): 弹幕列表

        Returns:
            int: 新增弹幕数量
        """
        writeXmlDm = []
        seniorDmCnt = 0
        nowAdd = 0
        for it in dmList:
            if int(it[7]) not in self.dmIdCnt:
                self.dmIdCnt.add(int(it[7]))
                # 写入弹幕
                writeXmlDm.append(
                    f'<d p="{it[0]},{it[1]},{it[2]},{it[3]},{it[4]},{it[5]},{it[6]},{it[7]},{it[8]}">{it[9]}</d>\n'
                )
                if int(it[1]) == 7:
                    seniorDmCnt += 1
                nowAdd += 1
        self.allDmCnt += nowAdd
        self.seniorDmCnt += seniorDmCnt
        self.queue.put(f"爬取 {date} 获取 {len(dmList)} 条弹幕; 新增 {nowAdd} 条弹幕, 高级弹幕新增 {seniorDmCnt} 条.")
        self.queue.put(writeXmlDm)
        return nowAdd
```